### PR TITLE
Start function app at given port when specified

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -63,9 +63,14 @@ export class FuncCli {
         const port = opts.port ?? 7071;
         const cwd = opts.cwd ?? process.cwd();
         const env = Object.assign({}, process.env, opts.env ?? {});
+        const args = ['start', '--verbose']
         this._opts = { port, cwd };
 
-        this._funcProcess = await spawnAndWait('func', ['start', '--verbose'], port, { cwd, env });
+        if (port) {
+            args.push('--port', port.toString())
+        }
+
+        this._funcProcess = await spawnAndWait('func', args, port, { cwd, env });
         this._funcProcess.stdout.on('data', (data?: Buffer) => {
             const dataText = data?.toString("utf8") ?? "";
             const lines = dataText.split(/\r?\n/);


### PR DESCRIPTION
Hello,

It looks like that the port provided to the function client start method is not passed to the azure function CLI for running the app

The following snippet
```typescript
// test.ts
import { FuncCli } from "@anthonychu/azure-functions-test-utils";

const funcCli = new FuncCli();
const promise = funcCli.start({
  port: 7072,
});

promise.then(() => console.log("app started")).catch(console.error);
```

when run ends with a timeout
```
$ npx ts-node test.ts 
npx: installed 17 in 2.292s
Error: Timed out waiting for: tcp:localhost:7072
    at C:\Users\...\node_modules\wait-on\lib\wait-on.js:132:31
    at doInnerSub (C:\Users\...\node_modules\rxjs\src\internal\operators\mergeInternals.ts:71:15)
    at outerNext (C:\Users\...\node_modules\rxjs\src\internal\operators\mergeInternals.ts:53:58)
    at OperatorSubscriber._this._next (C:\Users\...\node_modules\rxjs\src\internal\operators\OperatorSubscriber.ts:70:13)
    at OperatorSubscriber.Subscriber.next (C:\Users\...\node_modules\rxjs\src\internal\Subscriber.ts:75:12)
    at AsyncAction.<anonymous> (C:\Users\...\node_modules\rxjs\src\internal\observable\timer.ts:173:20)
    at AsyncAction._execute (C:\Users\...\node_modules\rxjs\src\internal\scheduler\AsyncAction.ts:116:12)
    at AsyncAction.execute (C:\Users\...\node_modules\rxjs\src\internal\scheduler\AsyncAction.ts:91:24)
    at AsyncScheduler.flush (C:\Users\...\node_modules\rxjs\src\internal\scheduler\AsyncScheduler.ts:39:27)
    at listOnTimeout (internal/timers.js:557:17)
``` 

According to source code, it looks to be normal
```typescript
// index.ts on line 62
async start(opts: { port?: number, cwd?: string, env?: {[key: string]: string} }): Promise<void> {
        const port = opts.port ?? 7071;
        const cwd = opts.cwd ?? process.cwd();
        const env = Object.assign({}, process.env, opts.env ?? {});
        this._opts = { port, cwd };

        this._funcProcess = await spawnAndWait('func', ['start', '--verbose'], port, { cwd, env });
```
The provided port is not passed to the `func start` command so the function start on TCP port 7071 by default but the client is waiting on the provided port (7072 in this example) to detect when it started.

I don't know if its intended or not, but I'm facing a situation where I'm using the function client with jest in several different test suites. Because suites are run in parallel, it tries to start and then close several function app on the same port which mess up tests. Moreover, I think it might be valuable to allow people to change the port at which the function app will run, in particular for testing to avoid any conflicts with a running function app